### PR TITLE
fix: fix sparo profile load path in SparoProfileService

### DIFF
--- a/apps/sparo-lib/src/services/SparoProfileService.ts
+++ b/apps/sparo-lib/src/services/SparoProfileService.ts
@@ -1,4 +1,5 @@
 import { FileSystem, Async } from '@rushstack/node-core-library';
+import path from 'path';
 import { inject } from 'inversify';
 import { Service } from '../decorator';
 import { SparoProfile } from '../logic/SparoProfile';
@@ -22,7 +23,12 @@ export class SparoProfileService {
   public async loadProfilesAsync(): Promise<void> {
     if (!this._loadPromise) {
       this._loadPromise = (async () => {
-        const sparoProfileFolder: string = defaultSparoProfileFolder;
+        const repoRoot: string = this._gitService.getRepoInfo().root;
+        const sparoProfileFolder: string = path.resolve(repoRoot, defaultSparoProfileFolder);
+        this._terminalService.terminal.writeDebugLine(
+          'loading sparse profiles from folder:',
+          sparoProfileFolder
+        );
         const sparoProfilePaths: string[] = await FileSystem.readFolderItemNamesAsync(sparoProfileFolder, {
           absolutePaths: true
         });

--- a/common/changes/sparo/fix-fix_sparse_service_load_path_2024-02-22-10-08.json
+++ b/common/changes/sparo/fix-fix_sparse_service_load_path_2024-02-22-10-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "fix load path in sparo profile service",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

### Summary
Fix load path in `SparoProfileService`. 
### Detail
If execute sparo inside a nested folder, sparo will throw errors like 
![image](https://github.com/tiktok/sparo/assets/22115706/810698d5-b2f0-4c1f-ad3b-8b0914514866)

This PR fixes this error by using `path.resolve` and calculate absolute path of sparo profiles folder with `repoRoot`