### PR TITLE
Fix checkout uncommitted sparo profile

### DIFF
--- a/apps/sparo-lib/src/cli/commands/checkout.ts
+++ b/apps/sparo-lib/src/cli/commands/checkout.ts
@@ -110,8 +110,18 @@ export class CheckoutCommand implements ICommand<ICheckoutCommandOptions> {
 
       const nonExistProfileNames: string[] = [];
       for (const targetProfileName of targetProfileNames) {
-        if (!this._sparoProfileService.hasProfile(targetProfileName, operationBranch)) {
-          nonExistProfileNames.push(targetProfileName);
+        /**
+         * If the operation branch is current branch, check the existence from file system.
+         * Otherwise, check the existence from git.
+         */
+        if (operationBranch === currentBranch) {
+          if (!this._sparoProfileService.hasProfileInFS(targetProfileName)) {
+            nonExistProfileNames.push(targetProfileName);
+          }
+        } else {
+          if (!this._sparoProfileService.hasProfileInGit(targetProfileName, operationBranch)) {
+            nonExistProfileNames.push(targetProfileName);
+          }
         }
       }
 

--- a/apps/sparo-lib/src/services/SparoProfileService.ts
+++ b/apps/sparo-lib/src/services/SparoProfileService.ts
@@ -23,8 +23,7 @@ export class SparoProfileService {
   public async loadProfilesAsync(): Promise<void> {
     if (!this._loadPromise) {
       this._loadPromise = (async () => {
-        const repoRoot: string = this._gitService.getRepoInfo().root;
-        const sparoProfileFolder: string = path.resolve(repoRoot, defaultSparoProfileFolder);
+        const sparoProfileFolder: string = this._sparoProfileFolder;
         this._terminalService.terminal.writeDebugLine(
           'loading sparse profiles from folder:',
           sparoProfileFolder
@@ -39,7 +38,7 @@ export class SparoProfileService {
             sparoProfile = await SparoProfile.loadFromFileAsync(this._terminalService, sparoProfilePath);
           } catch (e) {
             // TODO: more error handling
-            this._terminalService.terminal.writeLine((e as Error).message);
+            this._terminalService.terminal.writeErrorLine((e as Error).message);
           }
 
           if (sparoProfile) {
@@ -65,8 +64,19 @@ export class SparoProfileService {
     return this._profiles;
   }
 
-  public hasProfile(name: string, branch: string): boolean {
+  public hasProfileInGit(name: string, branch: string): boolean {
     return this._gitService.hasFile(`${defaultSparoProfileFolder}/${name}.json`, branch);
+  }
+
+  public hasProfileInFS(name: string): boolean {
+    const sparoProfileFilepath: string = path.resolve(this._sparoProfileFolder, `${name}.json`);
+    return FileSystem.exists(sparoProfileFilepath);
+  }
+
+  private get _sparoProfileFolder(): string {
+    const repoRoot: string = this._gitService.getRepoInfo().root;
+    const sparoProfileFolder: string = path.resolve(repoRoot, defaultSparoProfileFolder);
+    return sparoProfileFolder;
   }
 
   private static _getProfileName(profilePath: string): string {

--- a/common/changes/sparo/fix-checkout-uncommitted-sparo-profile_2024-02-22-22-26.json
+++ b/common/changes/sparo/fix-checkout-uncommitted-sparo-profile_2024-02-22-22-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Support checkout uncommitted sparo profiles",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Supports checkout to uncommitted sparo profile.

### How to test it
Local

![CleanShot 2024-02-22 at 14 29 22@2x](https://github.com/tiktok/sparo/assets/16147702/92d4b05c-8bf8-447b-8f0b-6044898aa4b7)

![CleanShot 2024-02-22 at 14 29 46@2x](https://github.com/tiktok/sparo/assets/16147702/83d8e4b9-f008-4b07-89f6-fe1856ba6c59)
