### PR TITLE
feat: support profile parameters in pull & clone command

### DIFF
--- a/apps/sparo-lib/src/cli/commands/cmd-list.ts
+++ b/apps/sparo-lib/src/cli/commands/cmd-list.ts
@@ -11,6 +11,7 @@ import { GitCheckoutCommand } from './git-checkout';
 import { GitFetchCommand } from './git-fetch';
 import { GitPullCommand } from './git-pull';
 import { InitProfileCommand } from './init-profile';
+import { PullCommand } from './pull';
 
 // When adding new Sparo subcommands, remember to update this doc page:
 // https://github.com/tiktok/sparo/blob/main/apps/website/docs/pages/commands/overview.md
@@ -22,6 +23,7 @@ export const COMMAND_LIST: Constructable[] = [
   CloneCommand,
   CheckoutCommand,
   FetchCommand,
+  PullCommand,
 
   // The commands customized by Sparo require a mirror command to Git
   GitCloneCommand,

--- a/apps/sparo-lib/src/cli/commands/cmd-list.ts
+++ b/apps/sparo-lib/src/cli/commands/cmd-list.ts
@@ -11,7 +11,7 @@ import { GitCheckoutCommand } from './git-checkout';
 import { GitFetchCommand } from './git-fetch';
 import { GitPullCommand } from './git-pull';
 import { InitProfileCommand } from './init-profile';
-import { PullCommand } from './pull';
+// import { PullCommand } from './pull';
 
 // When adding new Sparo subcommands, remember to update this doc page:
 // https://github.com/tiktok/sparo/blob/main/apps/website/docs/pages/commands/overview.md
@@ -23,7 +23,8 @@ export const COMMAND_LIST: Constructable[] = [
   CloneCommand,
   CheckoutCommand,
   FetchCommand,
-  PullCommand,
+  // Should be introduced after sparo merge|rebase
+  // PullCommand,
 
   // The commands customized by Sparo require a mirror command to Git
   GitCloneCommand,

--- a/apps/sparo-lib/src/cli/commands/list-profiles.ts
+++ b/apps/sparo-lib/src/cli/commands/list-profiles.ts
@@ -40,7 +40,7 @@ export class ListProfilesCommand implements ICommand<IListProfilesCommandOptions
     terminalService.terminal.writeLine();
 
     // ensure sparse profiles folder
-    this._gitSparseCheckoutService.initializeRepository();
+    this._gitSparseCheckoutService.ensureSkeletonExistAndUpdated();
 
     const sparoProfiles: Map<string, SparoProfile> = await this._sparoProfileService.getProfilesAsync();
 

--- a/apps/sparo-lib/src/cli/commands/pull.ts
+++ b/apps/sparo-lib/src/cli/commands/pull.ts
@@ -17,7 +17,7 @@ export interface IPullCommandOptions {
 @Command()
 export class PullCommand implements ICommand<IPullCommandOptions> {
   public cmd: string = 'pull [remote] [branch]';
-  public description: string = 'pull changes from remote branch to local';
+  public description: string = 'Incorporates changes from a remote repository into the current branch.';
 
   @inject(GitService) private _gitService!: GitService;
   @inject(SparoProfileService) private _sparoProfileService!: SparoProfileService;

--- a/apps/sparo-lib/src/cli/commands/pull.ts
+++ b/apps/sparo-lib/src/cli/commands/pull.ts
@@ -1,0 +1,95 @@
+import { inject } from 'inversify';
+import { Command } from '../../decorator';
+import { GitService } from '../../services/GitService';
+import { SparoProfileService } from '../../services/SparoProfileService';
+
+import type { Argv, ArgumentsCamelCase } from 'yargs';
+import type { ICommand } from './base';
+import type { TerminalService } from '../../services/TerminalService';
+
+export interface IPullCommandOptions {
+  branch?: string;
+  remote?: string;
+  profile?: string[];
+  addProfile?: string[];
+}
+
+@Command()
+export class PullCommand implements ICommand<IPullCommandOptions> {
+  public cmd: string = 'pull [remote] [branch]';
+  public description: string = 'pull changes from remote branch to local';
+
+  @inject(GitService) private _gitService!: GitService;
+  @inject(SparoProfileService) private _sparoProfileService!: SparoProfileService;
+
+  public builder(yargs: Argv<{}>): void {
+    /**
+     * sparo pull [remote] [branch] --profile <profile_name> --add-profile <profile_name> --no-profile
+     */
+    yargs
+      .positional('remote', { type: 'string' })
+      .positional('branch', { type: 'string' })
+      .string('remote')
+      .string('branch')
+      .boolean('full')
+      .array('profile')
+      .default('profile', [])
+      .array('add-profile')
+      .default('add-profile', []);
+  }
+
+  public handler = async (
+    args: ArgumentsCamelCase<IPullCommandOptions>,
+    terminalService: TerminalService
+  ): Promise<void> => {
+    const { _gitService: gitService, _sparoProfileService: sparoProfileService } = this;
+    const { terminal } = terminalService;
+
+    terminal.writeDebugLine(`got args in pull command: ${JSON.stringify(args)}`);
+    const pullArgs: string[] = ['pull'];
+
+    const { branch, remote } = args;
+
+    if (branch && remote) {
+      pullArgs.push(remote, branch);
+    }
+
+    const { isNoProfile, profiles, addProfiles } = await sparoProfileService.preprocessProfileArgs({
+      profilesFromArg: args.profile ?? [],
+      addProfilesFromArg: args.addProfile ?? []
+    });
+
+    // invoke native git pull command
+    gitService.executeGitCommand({ args: pullArgs });
+
+    // check whether profile exist in local branch
+    if (!isNoProfile) {
+      const targetProfileNames: Set<string> = new Set([...profiles, ...addProfiles]);
+      const nonExistProfileNames: string[] = [];
+      for (const targetProfileName of targetProfileNames) {
+        if (!this._sparoProfileService.hasProfileInFS(targetProfileName)) {
+          nonExistProfileNames.push(targetProfileName);
+        }
+      }
+
+      if (nonExistProfileNames.length) {
+        const { branch } = gitService.getRepoInfo();
+        throw new Error(
+          `Pull failed. The following profile(s) are missing in local branch "${branch}": ${Array.from(
+            targetProfileNames
+          ).join(', ')}`
+        );
+      }
+    }
+
+    // sync local sparse checkout state with given profiles.
+    await this._sparoProfileService.syncProfileState({
+      profiles: isNoProfile ? undefined : profiles,
+      addProfiles
+    });
+  };
+
+  public getHelp(): string {
+    return `pull help`;
+  }
+}

--- a/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
+++ b/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
@@ -86,6 +86,10 @@ export class GitSparseCheckoutService {
     await this._rushSparseCheckoutAsync({ checkoutAction: 'purge' });
   }
 
+  /**
+   *
+   * @param options
+   */
   private async _rushSparseCheckoutAsync(options: IRushSparseCheckoutOptions): Promise<void> {
     const {
       to,
@@ -179,6 +183,17 @@ export class GitSparseCheckoutService {
 
     {
       const stopwatch: Stopwatch = Stopwatch.start();
+      /**
+       * Perform different logic based on checkoutAction
+       *
+       *   "purge"  : reset repo to skeleton, will remove other paths in checkout paths list
+       *
+       * "skeleton" : checkout skeleton in repo, will only add skeleton paths to checkout paths list
+       *
+       *    "set"   : set checkout paths list by invoking "git sparse-checkout set", will implicitly add skeleton paths to this list.
+       *
+       *    "add"   : add a list of paths to checkout list by invoking "git sparse-checkout add"
+       */
       switch (checkoutAction) {
         case 'purge':
         case 'skeleton':

--- a/apps/sparo-lib/src/services/SparoProfileService.ts
+++ b/apps/sparo-lib/src/services/SparoProfileService.ts
@@ -236,11 +236,6 @@ ${availableProfiles.join(',')}
     profiles?: Set<string>;
     addProfiles?: Set<string>;
   }): Promise<void> {
-    /*
-     * 2. If profile array is specified, using `git sparse-checkout set` to set sparse checkout folders in profiles.
-     * 3. If add profiles is specified, using `git sparse-checkout add` to add folders in add profiles
-     */
-
     this._localState.reset();
     this._terminalService.terminal.writeLine(
       `Syncing local sparse checkout state with following specified profiles:\n${Array.from([

--- a/common/changes/sparo/feat-support_profile_parameters_in_pull_2024-02-28-12-40.json
+++ b/common/changes/sparo/feat-support_profile_parameters_in_pull_2024-02-28-12-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "support profile related parameters in pull & clone command",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


### Summary
Support profile related parameters in pull & clone command

### Detail
* add function `ensureSkeletonExistAndUpdated` in `GitSparseCheckoutService`  to avoid duplicated initialization for skeleton.
* add new pull command in sparo with profile related parameters support.
* add profile related parameters support in clone command.
* `resolveSparoProfileAsync` function was moved to `SparoProfileService`
* add `preprocessProfileArgs` and `syncProfileState` in `SparoProfileService` for code sharing. 

Notice:
Unlike `sparo checkout` command, clone and pull command will invoke native git command first and try to get profile in local file system.

### How to test it
Manually tested. 
