### PR TITLE
feat: improve error logs when running rush list failed

### DIFF
--- a/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
+++ b/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
@@ -416,6 +416,10 @@ ${availableProfiles.join(',')}
       stdio: ['pipe', 'pipe', 'pipe']
     });
 
+    if (result.status !== 0) {
+      throw new Error(`Get projects from selections failed: ${result.stderr}`);
+    }
+
     const processedResult: string = this._processListResult(result.stdout.toString());
 
     terminal.writeVerboseLine(processedResult);

--- a/common/changes/sparo/feat-improve-checkout-error-log_2024-02-29-22-00.json
+++ b/common/changes/sparo/feat-improve-checkout-error-log_2024-02-29-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Improve error logs when get projects from selection failed",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Improve error log when profile is selecting a tag specified with no projects.

### Detail

![CleanShot 2024-02-29 at 14 02 24@2x](https://github.com/tiktok/sparo/assets/16147702/2af5612e-465c-495b-a73a-25a30a707aca)


### How to test it
