### PR TITLE
fix: --profile checkout local status

### DIFF
--- a/apps/sparo-lib/src/cli/commands/checkout.ts
+++ b/apps/sparo-lib/src/cli/commands/checkout.ts
@@ -107,7 +107,7 @@ export class CheckoutCommand implements ICommand<ICheckoutCommandOptions> {
       }
     }
 
-    const targetProfileNames: Set<string> = new Set();
+    let targetProfileNames: Set<string> = new Set();
     const currentProfileNames: Set<string> = new Set();
     if (!isNoProfile) {
       // Get target profile.
@@ -116,13 +116,16 @@ export class CheckoutCommand implements ICommand<ICheckoutCommandOptions> {
       // 3. If add profile was specified from CLI parameter, add them to result of 1 or 2.
       const localStateProfiles: ILocalStateProfiles | undefined = await localState.getProfiles();
 
-      if (profiles.size) {
-        profiles.forEach((p) => targetProfileNames.add(p));
-      } else if (localStateProfiles) {
+      if (localStateProfiles) {
         Object.keys(localStateProfiles).forEach((p) => {
           targetProfileNames.add(p);
           currentProfileNames.add(p);
         });
+      }
+
+      if (profiles.size) {
+        targetProfileNames = new Set();
+        profiles.forEach((p) => targetProfileNames.add(p));
       }
 
       if (addProfiles.size) {

--- a/common/changes/sparo/fix-profile_checkout_status_2024-03-04-07-44.json
+++ b/common/changes/sparo/fix-profile_checkout_status_2024-03-04-07-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "fix sparse checkout paths status after checkout to a specific --profile",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

If the user specifies --profile, we will utilize the internal profile purge logic firstly to clear the existing checkout paths before applying the new profile.

### Detail

### How to test it
