### PR TITLE
chore: use path.parse instead of split

### DIFF
--- a/apps/sparo-lib/src/services/SparoProfileService.ts
+++ b/apps/sparo-lib/src/services/SparoProfileService.ts
@@ -107,12 +107,8 @@ export class SparoProfileService {
   }
 
   private static _getProfileName(profilePath: string): string {
-    const pathArr: string[] = profilePath.split(path.sep);
-    const last: string = pathArr[pathArr.length - 1];
-    if (last.endsWith('.json')) {
-      return last.slice(0, -5);
-    }
-    return last;
+    const parsed: path.ParsedPath = path.parse(profilePath);
+    return parsed.name;
   }
 
   public async resolveSparoProfileAsync(

--- a/common/changes/sparo/main_2024-03-05-03-36.json
+++ b/common/changes/sparo/main_2024-03-05-03-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

### Detail
![image](https://github.com/tiktok/sparo/assets/68707557/5214332d-6a36-429a-906c-67525d3c7fea)

![image](https://github.com/tiktok/sparo/assets/68707557/f770d373-20ea-4a7d-858d-e0b99e5bed6c)

Since it has already been determined whether it is a JSON file before calling the `_getProfileName` function, there is no need for a secondary verification here

### How to test it
