### PR TITLE
chore: final tweak before 1.0

### DIFF
--- a/apps/sparo-lib/src/cli/commands/init-profile.ts
+++ b/apps/sparo-lib/src/cli/commands/init-profile.ts
@@ -27,7 +27,8 @@ export class InitProfileCommand implements ICommand<IInitProjectCommandOptions> 
         type: 'string',
         description: 'The name of the profile to initialize.'
       })
-      .demandOption(['profile']);
+      .demandOption(['profile'])
+      .usage('Usage: $0 init-profile --profile <profile>');
   }
 
   public handler = async (

--- a/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
+++ b/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
@@ -216,7 +216,8 @@ export class GitSparseCheckoutService {
             if (checkoutAction === 'set') {
               targetFolders.push(...this._finalSkeletonPaths);
             }
-            terminal.writeLine(
+            terminal.writeLine(`Checking out ${targetFolders.length} folders...`);
+            terminal.writeDebugLine(
               `Performing sparse checkout ${checkoutAction} for these folders: \n${targetFolders.join('\n')}`
             );
 

--- a/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
+++ b/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
@@ -50,10 +50,13 @@ export class GitSparseCheckoutService {
     if ('true' !== this._gitService.getGitConfig('core.sparsecheckout')?.trim()) {
       throw new Error('Sparse checkout is not enabled in this repo.');
     }
-    this.initializeAndUpdateSkeleton();
+    this._initializeAndUpdateSkeleton();
   }
 
-  public initializeAndUpdateSkeleton(): void {
+  /**
+   * Other services should call ensureSkeletonExistAndUpdated
+   */
+  private _initializeAndUpdateSkeleton(): void {
     this._terminalService.terminal.writeLine('Checking out and updating core files...');
     this._loadRushConfiguration();
     this._prepareMonorepoSkeleton();
@@ -196,11 +199,13 @@ export class GitSparseCheckoutService {
        */
       switch (checkoutAction) {
         case 'purge':
-        case 'skeleton':
           // re-apply the initial paths for setting up sparse repo state
           this._prepareMonorepoSkeleton({
             restore: checkoutAction === 'purge'
           });
+          break;
+        case 'skeleton':
+          // Skeleton should be always prepared in the beginning of the function
           break;
         case 'add':
         case 'set':
@@ -266,6 +271,7 @@ export class GitSparseCheckoutService {
   private _prepareMonorepoSkeleton(options: { restore?: boolean } = {}): void {
     const { restore } = options;
     this._finalSkeletonPaths = this._getSkeletonPaths();
+    this._terminalService.terminal.writeLine('Checking out skeleton...');
     this._terminalService.terminal.writeDebugLine(`Skeleton paths: ${this._finalSkeletonPaths.join(', ')}`);
     this._sparseCheckoutPaths(this._finalSkeletonPaths, {
       action: restore ? 'set' : 'add'

--- a/apps/sparo-lib/src/services/SparoProfileService.ts
+++ b/apps/sparo-lib/src/services/SparoProfileService.ts
@@ -237,12 +237,14 @@ ${availableProfiles.join(',')}
     addProfiles?: Set<string>;
   }): Promise<void> {
     this._localState.reset();
-    this._terminalService.terminal.writeLine(
-      `Syncing local sparse checkout state with following specified profiles:\n${Array.from([
-        ...(profiles ?? []),
-        ...(addProfiles ?? [])
-      ]).join('\n')}`
-    );
+    const allProfiles: string[] = Array.from([...(profiles ?? []), ...(addProfiles ?? [])]);
+    if (allProfiles.length) {
+      this._terminalService.terminal.writeLine(
+        `Syncing local sparse checkout state with following specified profiles:\n${allProfiles.join('\n')}`
+      );
+    } else {
+      this._terminalService.terminal.writeLine('Syncing local sparse checkout state with no profile');
+    }
     this._terminalService.terminal.writeLine();
     if (!profiles || profiles.size === 0) {
       // If no profile was specified, purge local state to skeleton

--- a/apps/sparo-lib/src/services/SparoProfileService.ts
+++ b/apps/sparo-lib/src/services/SparoProfileService.ts
@@ -238,12 +238,16 @@ ${availableProfiles.join(',')}
   }): Promise<void> {
     this._localState.reset();
     const allProfiles: string[] = Array.from([...(profiles ?? []), ...(addProfiles ?? [])]);
-    if (allProfiles.length) {
+    if (allProfiles.length > 1) {
       this._terminalService.terminal.writeLine(
-        `Syncing local sparse checkout state with following specified profiles:\n${allProfiles.join('\n')}`
+        `Syncing checkout with these Sparo profiles:\n${allProfiles.join(', ')}`
+      );
+    } else if (allProfiles.length === 1) {
+      this._terminalService.terminal.writeLine(
+        `Syncing checkout with the Sparo profile: ${allProfiles[0]}`
       );
     } else {
-      this._terminalService.terminal.writeLine('Syncing local sparse checkout state with no profile');
+      this._terminalService.terminal.writeLine('Syncing checkout with the Sparo skeleton (no profile selection)');
     }
     this._terminalService.terminal.writeLine();
     if (!profiles || profiles.size === 0) {

--- a/common/changes/sparo/feat-support_profile_parameters_in_pull_2024-02-28-12-40.json
+++ b/common/changes/sparo/feat-support_profile_parameters_in_pull_2024-02-28-12-40.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "sparo",
-      "comment": "support profile related parameters in pull & clone command",
+      "comment": "Support --profile parameter in clone command",
       "type": "none"
     }
   ],

--- a/common/changes/sparo/tweak-1_2024-03-05-04-01.json
+++ b/common/changes/sparo/tweak-1_2024-03-05-04-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

### Detail

1. Remove `--add-profile` in `sparo clone`
2. Improve help text for "sparo init-profile"
3. Improve logs in "syncProfileState" function

### How to test it
