### PR TITLE
Fix find plugin paths

### DIFF
--- a/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
+++ b/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
@@ -250,8 +250,7 @@ export class GitSparseCheckoutService {
       return;
     }
 
-    const monorepoRoot: string = this._gitService.getRepoInfo().root;
-    const rushJsonPath: string = path.resolve(monorepoRoot, 'rush.json');
+    const rushJsonPath: string = path.resolve(this._monorepoRoot, 'rush.json');
 
     if (!FileSystem.exists(rushJsonPath)) {
       throw new Error('Missing rush.json. Do you work in a Rush.js monorepo?');
@@ -267,6 +266,11 @@ export class GitSparseCheckoutService {
       this._rushProjects.push(project);
       this._packageNames.add(project.packageName);
     });
+  }
+
+  private get _monorepoRoot(): string {
+    const monorepoRoot: string = this._gitService.getRepoInfo().root;
+    return monorepoRoot;
   }
 
   private _prepareMonorepoSkeleton(options: { restore?: boolean } = {}): void {
@@ -300,7 +304,7 @@ export class GitSparseCheckoutService {
   }
 
   private _findRushPluginsPaths(): string[] {
-    const autoInstallerPath: string = path.resolve('common', 'autoinstallers');
+    const autoInstallerPath: string = path.resolve(this._monorepoRoot, 'common', 'autoinstallers');
     const ignoreNames: Set<string> = new Set(['node_modules']);
     const rushPluginPaths: string[] = [];
 

--- a/common/changes/sparo/fix-find-plugin-paths_2024-03-08-23-42.json
+++ b/common/changes/sparo/fix-find-plugin-paths_2024-03-08-23-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Fix finding rush plugin paths issue in a subfolder of repository",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Fix the find plugin paths logic under a subfolder of repository.

### Detail

### How to test it

Local
