### PR TITLE
feat: Sparo checkout support --to/--from option for direct projects selection

### DIFF
--- a/apps/sparo-lib/src/services/SparoProfileService.ts
+++ b/apps/sparo-lib/src/services/SparoProfileService.ts
@@ -322,9 +322,11 @@ ${availableProfiles.join(',')}
       });
     }
 
-    await this._gitSparseCheckoutService.checkoutAsync({
-      selections: projectsSelections,
-      checkoutAction: 'add'
-    });
+    if (projectsSelections.length > 0) {
+      await this._gitSparseCheckoutService.checkoutAsync({
+        selections: projectsSelections,
+        checkoutAction: 'add'
+      });
+    }
   }
 }

--- a/apps/website/docs/pages/commands/sparo_checkout.md
+++ b/apps/website/docs/pages/commands/sparo_checkout.md
@@ -20,4 +20,19 @@ Options:
                      already exists, reset it to <start-point>         [boolean]
       --profile                                            [array] [default: []]
       --add-profile                                        [array] [default: []]
+      --to           Checkout projects up to (and including) project <to..>, can
+                     be used together with option --profile/--add-profile to
+                     form a union selection of the two options. The projects
+                     selectors here will never replace what have been checked
+                     out by profiles                       [array] [default: []]
+      --from         Checkout projects downstream from (and including itself and
+                     all its dependencies) project <from..>, can be used
+                     together with option --profile/--add-profile to form a
+                     union selection of the two options. The projects selectors
+                     here will never replace what have been checked out by
+                     profiles                              [array] [default: []]
 ```
+
+
+
+

--- a/build-tests/sparo-output-test/etc/checkout-help.txt
+++ b/build-tests/sparo-output-test/etc/checkout-help.txt
@@ -21,3 +21,5 @@ Options:
                      already exists, reset it to <start-point>         [boolean]
       --profile                                            [array] [default: []]
       --add-profile                                        [array] [default: []]
+      --to                                                 [array] [default: []]
+      --from                                               [array] [default: []]

--- a/build-tests/sparo-output-test/etc/checkout-help.txt
+++ b/build-tests/sparo-output-test/etc/checkout-help.txt
@@ -19,7 +19,16 @@ Options:
   -b                 Create a new branch and start it at <start-point> [boolean]
   -B                 Create a new branch and start it at <start-point>; if it
                      already exists, reset it to <start-point>         [boolean]
+      --to           Checkout projects up to (and including) project <to..>, can
+                     be used together with option --profile/--add-profile to
+                     form a union selection of the two options. The projects
+                     selectors here will never replace what have been checked
+                     out by profiles                       [array] [default: []]
+      --from         Checkout projects downstream from (and including itself and
+                     all its dependencies) project <from..>, can be used
+                     together with option --profile/--add-profile to form a
+                     union selection of the two options. The projects selectors
+                     here will never replace what have been checked out by
+                     profiles                              [array] [default: []]
       --profile                                            [array] [default: []]
       --add-profile                                        [array] [default: []]
-      --to                                                 [array] [default: []]
-      --from                                               [array] [default: []]

--- a/build-tests/sparo-real-repo-test/etc/checkout-from.txt
+++ b/build-tests/sparo-real-repo-test/etc/checkout-from.txt
@@ -1,0 +1,29 @@
+Running "sparo checkout --from build-test-utilities":
+
+[bold]Sparo accelerator for Git __VERSION__ -[normal][cyan] https://tiktok.github.io/sparo/[default]
+Node.js version is __VERSION__ (LTS)
+Git version is __VERSION__
+
+
+[gray]--[[default] [bold]git checkout[normal] [gray]]-------------------------------------------------------------[default]
+Your branch is up to date with 'origin/test-artifacts/sparo-real-repo-test'.
+[gray]-------------------------------------------------------------------------------[default]
+
+Syncing checkout with the Sparo profile: my-build-test
+
+Checking out and updating core files...
+
+[gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]
+[gray]-------------------------------------------------------------------------------[default]
+
+Checking out skeleton...
+
+[gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]
+[gray]-------------------------------------------------------------------------------[default]
+
+Checking out __FOLDER_COUNT__ folders...
+
+[gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]
+[gray]-------------------------------------------------------------------------------[default]
+
+Sparse checkout completed in __DURATION__

--- a/build-tests/sparo-real-repo-test/etc/checkout-from.txt
+++ b/build-tests/sparo-real-repo-test/etc/checkout-from.txt
@@ -1,4 +1,4 @@
-Running "sparo checkout --from build-test-utilities":
+Running "sparo checkout --from sparo":
 
 [bold]Sparo accelerator for Git __VERSION__ -[normal][cyan] https://tiktok.github.io/sparo/[default]
 Node.js version is __VERSION__ (LTS)
@@ -21,6 +21,12 @@ Checking out skeleton...
 [gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]
 [gray]-------------------------------------------------------------------------------[default]
 
+Checking out __FOLDER_COUNT__ folders...
+
+[gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]
+[gray]-------------------------------------------------------------------------------[default]
+
+Sparse checkout completed in __DURATION__
 Checking out __FOLDER_COUNT__ folders...
 
 [gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]

--- a/build-tests/sparo-real-repo-test/etc/checkout-to.txt
+++ b/build-tests/sparo-real-repo-test/etc/checkout-to.txt
@@ -1,0 +1,35 @@
+Running "sparo checkout --to sparo-output-test":
+
+[bold]Sparo accelerator for Git __VERSION__ -[normal][cyan] https://tiktok.github.io/sparo/[default]
+Node.js version is __VERSION__ (LTS)
+Git version is __VERSION__
+
+
+[gray]--[[default] [bold]git checkout[normal] [gray]]-------------------------------------------------------------[default]
+Your branch is up to date with 'origin/test-artifacts/sparo-real-repo-test'.
+[gray]-------------------------------------------------------------------------------[default]
+
+Syncing checkout with the Sparo profile: my-build-test
+
+Checking out and updating core files...
+
+[gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]
+[gray]-------------------------------------------------------------------------------[default]
+
+Checking out skeleton...
+
+[gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]
+[gray]-------------------------------------------------------------------------------[default]
+
+Checking out __FOLDER_COUNT__ folders...
+
+[gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]
+[gray]-------------------------------------------------------------------------------[default]
+
+Sparse checkout completed in __DURATION__
+Checking out __FOLDER_COUNT__ folders...
+
+[gray]--[[default] [bold]git sparse-checkout[normal] [gray]]------------------------------------------------------[default]
+[gray]-------------------------------------------------------------------------------[default]
+
+Sparse checkout completed in __DURATION__

--- a/build-tests/sparo-real-repo-test/src/start-test.ts
+++ b/build-tests/sparo-real-repo-test/src/start-test.ts
@@ -80,6 +80,20 @@ export async function runAsync(runScriptOptions: IRunScriptOptions): Promise<voi
       args: ['checkout', '--profile', 'my-build-test'],
       currentWorkingDirectory: repoFolder
     },
+    // sparo checkout --to sparo-output-test
+    {
+      kind: 'sparo-command',
+      name: 'checkout-to',
+      args: ['checkout', '--to', 'sparo-output-test'],
+      currentWorkingDirectory: repoFolder
+    },
+    // sparo checkout --from build-test-utilities
+    {
+      kind: 'sparo-command',
+      name: 'checkout-from',
+      args: ['checkout', '--from', 'build-test-utilities'],
+      currentWorkingDirectory: repoFolder
+    },
     // sparo list-profiles
     {
       kind: 'sparo-command',

--- a/build-tests/sparo-real-repo-test/src/start-test.ts
+++ b/build-tests/sparo-real-repo-test/src/start-test.ts
@@ -91,7 +91,7 @@ export async function runAsync(runScriptOptions: IRunScriptOptions): Promise<voi
     {
       kind: 'sparo-command',
       name: 'checkout-from',
-      args: ['checkout', '--from', 'build-test-utilities'],
+      args: ['checkout', '--from', 'sparo'],
       currentWorkingDirectory: repoFolder
     },
     // sparo list-profiles

--- a/common/changes/sparo/feat-checkout-to-selector_2024-04-25-14-16.json
+++ b/common/changes/sparo/feat-checkout-to-selector_2024-04-25-14-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "sparo",
-      "comment": "[sparo checkout] support cli --to/--from option for projects seletion",
+      "comment": "[sparo checkout] support cli --to/--from option for projects selection",
       "type": "none"
     }
   ],

--- a/common/changes/sparo/feat-checkout-to-selector_2024-04-25-14-16.json
+++ b/common/changes/sparo/feat-checkout-to-selector_2024-04-25-14-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "[sparo checkout] support cli --to/--from option for projects seletion",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [x] Reason for adding this feature
Instead of creating Sparo Profiles, sometimes I just want to checkout some projects randomly based on [RushJS selector](https://rushjs.io/pages/developer/selecting_subsets/). 
- [x] How to use
`sparo checkout --to project-A project-B --from project-C project-D`
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

### Detail

### How to test it
