### PR TITLE
Feat checkout detched

### DIFF
--- a/apps/sparo-lib/src/cli/commands/checkout.ts
+++ b/apps/sparo-lib/src/cli/commands/checkout.ts
@@ -111,7 +111,14 @@ export class CheckoutCommand implements ICommand<ICheckoutCommandOptions> {
     }
 
     if (!operationBranch) {
-      throw new Error(`Failed to get branch ${operationBranch}`);
+      if (!currentBranch) {
+        // If current branch is missing, it means the repository is in a detached HEAD state.
+        // Let's treat it as a commit SHA for convenience now.
+        checkoutTargetKind = 'commit';
+      } else {
+        // This should not happen
+        throw new Error(`Failed to get branch ${operationBranch}`);
+      }
     } else {
       if (operationBranch !== currentBranch) {
         // 1. First, Sparo needs to see the branch matches any branch name

--- a/common/changes/sparo/feat-checkout-detched_2024-04-30-17-33.json
+++ b/common/changes/sparo/feat-checkout-detched_2024-04-30-17-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Fix checkout command in a detached HEAD state",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Fix error when running "sparo checkout" in a detached HEAD state

### Detail

`sparo checkout <commit_hash>` can checkout to a detached HEAD state. Running "sparo checkout" again throws error which complains about "Failed to get branch name". This PR fixes this issue to allow "checkout" command in this case.

### How to test it
