### PR TITLE
Feat sparo branch

### DIFF
--- a/apps/sparo-lib/src/cli/commands/branch.ts
+++ b/apps/sparo-lib/src/cli/commands/branch.ts
@@ -1,0 +1,127 @@
+import { inject } from 'inversify';
+import { GitService } from '../../services/GitService';
+import { GracefulShutdownService } from '../../services/GracefulShutdownService';
+import { TerminalService } from '../../services/TerminalService';
+
+import type { ArgumentsCamelCase, Argv } from 'yargs';
+import type { ICommand } from './base';
+import type { SpawnSyncReturns } from 'child_process';
+
+export interface IBranchCommandOptions {
+  delete: boolean;
+  // Force delete
+  D: boolean;
+  branch?: string;
+}
+
+export class BranchCommand implements ICommand<IBranchCommandOptions> {
+  public cmd: string = 'branch [branch]';
+  public description: string = 'List, create, or delete branches';
+
+  @inject(GitService) private _gitService!: GitService;
+  @inject(GracefulShutdownService) private _gracefulShutdownService!: GracefulShutdownService;
+  @inject(TerminalService) private _terminalService!: TerminalService;
+
+  public builder(yargs: Argv<{}>): void {
+    yargs
+      .option('delete', {
+        alias: 'd',
+        describe:
+          'Delete a branch. The branch must be fully merged in its upstream branch, or in HEAD if no upstream was set with --track or --set-upstream-to.',
+        default: false,
+        type: 'boolean'
+      })
+      .option('D', {
+        description: 'Shortcut for --delete --force',
+        default: false,
+        type: 'boolean'
+      })
+      .positional('branch', {
+        type: 'string'
+      })
+      .parserConfiguration({ 'unknown-options-as-args': true });
+  }
+
+  public handler = async (
+    args: ArgumentsCamelCase<IBranchCommandOptions>,
+    terminalService: TerminalService
+  ): Promise<void> => {
+    const { terminal } = terminalService;
+    const { _gitService: gitService } = this;
+    terminal.writeDebugLine(`got args in branch command: ${JSON.stringify(args)}`);
+
+    // Collect raw args
+    const branchArgs: string[] = args._ as string[];
+
+    const { branch } = args;
+    const isDelete: boolean = args.delete;
+    const isForceDelete: boolean = args.D;
+
+    if (branch) {
+      branchArgs.splice(1, 0, branch);
+    }
+    if (isForceDelete) {
+      branchArgs.splice(1, 0, '-D');
+    } else if (isDelete) {
+      branchArgs.splice(1, 0, '-d');
+    }
+
+    const result: SpawnSyncReturns<string> = gitService.executeGitCommand({
+      args: branchArgs
+    });
+
+    if (result.status === 0) {
+      if ((isDelete || isForceDelete) && branch) {
+        this._removeRemoteBranchIfNecessary(branch);
+      }
+    }
+  };
+
+  public getHelp(): string {
+    return '';
+  }
+
+  private _removeRemoteBranchIfNecessary(branch: string): void {
+    const remote: string = this._gitService.getBranchRemote(branch);
+
+    const result: string | undefined = this._gitService.getGitConfig(`remote.${remote}.fetch`, {
+      array: true
+    });
+
+    const remoteFetchGitConfig: string[] | undefined = result?.split('\n').filter(Boolean);
+    if (remoteFetchGitConfig) {
+      const targetConfig: string = `+refs/heads/${branch}:refs/remotes/${remote}/${branch}`;
+
+      // With set structure, duplicate target configurations can be removed in a single run
+      const remoteFetchGitConfigSet: Set<string> = new Set<string>(remoteFetchGitConfig);
+      if (remoteFetchGitConfigSet.has(targetConfig)) {
+        // There is no easy way to unset one branch configuration,
+        // So, delete all configuration and restores branches except the target branch
+
+        // Restore previous git config if something went wrong
+        const callback = (): void => {
+          this._setRemoteFetchGitConfig(remote, remoteFetchGitConfig);
+          this._terminalService.terminal.writeDebugLine(
+            `Restored previous remote.${remote}.fetch configuration`
+          );
+        };
+
+        remoteFetchGitConfigSet.delete(targetConfig);
+
+        const updatedRemoteFetchGitConfig: string[] = Array.from(remoteFetchGitConfigSet);
+
+        this._gracefulShutdownService.registerCallback(callback);
+        this._setRemoteFetchGitConfig(remote, updatedRemoteFetchGitConfig);
+        this._terminalService.terminal.writeDebugLine(`Removed branch "${branch}" in remote.${remote}.fetch`);
+        this._gracefulShutdownService.unregisterCallback(callback);
+      }
+    }
+  }
+
+  private _setRemoteFetchGitConfig(remote: string, remoteFetchGitConfig: string[]): void {
+    this._gitService.unsetGitConfig(`remote.${remote}.fetch`);
+    for (const value of remoteFetchGitConfig) {
+      this._gitService.setGitConfig(`remote.${remote}.fetch`, value, { add: true });
+    }
+  }
+}

--- a/apps/sparo-lib/src/cli/commands/cmd-list.ts
+++ b/apps/sparo-lib/src/cli/commands/cmd-list.ts
@@ -12,6 +12,7 @@ import { GitFetchCommand } from './git-fetch';
 import { GitPullCommand } from './git-pull';
 import { InitProfileCommand } from './init-profile';
 import { PullCommand } from './pull';
+import { BranchCommand } from './branch';
 
 // When adding new Sparo subcommands, remember to update this doc page:
 // https://github.com/tiktok/sparo/blob/main/apps/website/docs/pages/commands/overview.md
@@ -24,6 +25,7 @@ export const COMMAND_LIST: Constructable[] = [
   CheckoutCommand,
   FetchCommand,
   PullCommand,
+  BranchCommand,
 
   // The commands customized by Sparo require a mirror command to Git
   GitCloneCommand,

--- a/apps/sparo-lib/src/cli/commands/cmd-list.ts
+++ b/apps/sparo-lib/src/cli/commands/cmd-list.ts
@@ -13,6 +13,7 @@ import { GitPullCommand } from './git-pull';
 import { InitProfileCommand } from './init-profile';
 import { PullCommand } from './pull';
 import { BranchCommand } from './branch';
+import { GitBranchCommand } from './git-branch';
 
 // When adding new Sparo subcommands, remember to update this doc page:
 // https://github.com/tiktok/sparo/blob/main/apps/website/docs/pages/commands/overview.md
@@ -31,7 +32,8 @@ export const COMMAND_LIST: Constructable[] = [
   GitCloneCommand,
   GitCheckoutCommand,
   GitFetchCommand,
-  GitPullCommand
+  GitPullCommand,
+  GitBranchCommand
 ];
 
 export const CI_COMMAND_LIST: Constructable[] = [CICloneCommand, CICheckoutCommand];

--- a/apps/sparo-lib/src/cli/commands/git-branch.ts
+++ b/apps/sparo-lib/src/cli/commands/git-branch.ts
@@ -1,0 +1,33 @@
+import { inject } from 'inversify';
+import { GitService } from '../../services/GitService';
+
+import type { ICommand } from './base';
+import type { ArgumentsCamelCase, Argv } from 'yargs';
+import type { TerminalService } from '../../services/TerminalService';
+
+export class GitBranchCommand implements ICommand<{}> {
+  public cmd: string = 'git-branch';
+  public description: string = 'original git branch command';
+
+  @inject(GitService) private _gitService!: GitService;
+
+  public builder(yargs: Argv<{}>): void {
+    yargs.help(false);
+  }
+
+  public handler = async (args: ArgumentsCamelCase<{}>, terminalService: TerminalService): Promise<void> => {
+    const { _gitService: gitService } = this;
+    const { terminal } = terminalService;
+    const rawArgs: string[] = process.argv.slice(2);
+    const index: number = rawArgs.indexOf(this.cmd);
+    if (index >= 0) {
+      rawArgs[index] = 'branch';
+    }
+    terminal.writeDebugLine(`proxy args in git-branch command: ${JSON.stringify(rawArgs)}`);
+    gitService.executeGitCommand({ args: rawArgs });
+  };
+
+  public getHelp(): string {
+    return `git-branch help`;
+  }
+}

--- a/apps/website/docs/pages/commands/overview.md
+++ b/apps/website/docs/pages/commands/overview.md
@@ -13,12 +13,14 @@ Sparo has four kinds of subcommands:
    - `sparo clone`
    - `sparo fetch`
    - `sparo pull`
+   - `sparo branch`
 
 3. **Renamed subcommands** are the mirrored versions of the four enhanced subcommands. They are renamed to add a `git-` prefix:
   - `sparo git-checkout`
   - `sparo git-clone`
   - `sparo git-fetch`
   - `sparo git-pull`
+  - `sparo git-branch`
 
 4. **Auxiliary subcommands** are new subcommands that provide Sparo-specific functionality.  They are:
   - `sparo auto-config`

--- a/apps/website/docs/pages/commands/sparo_branch.md
+++ b/apps/website/docs/pages/commands/sparo_branch.md
@@ -1,0 +1,19 @@
+---
+title: sparo branch
+---
+
+```
+sparo branch [branch]
+
+List, create, or delete branches
+
+Positionals:
+  branch                                                                [string]
+
+Options:
+      --help    Show help                                              [boolean]
+  -d, --delete  Delete a branch. The branch must be fully merged in its upstream
+                branch, or in HEAD if no upstream was set with --track or
+                --set-upstream-to.                    [boolean] [default: false]
+  -D            Shortcut for --delete --force         [boolean] [default: false]
+```

--- a/apps/website/docs/pages/commands/sparo_git-branch.md
+++ b/apps/website/docs/pages/commands/sparo_git-branch.md
@@ -1,0 +1,27 @@
+---
+title: sparo git-branch
+---
+
+This is the [mirrored subcommand](./overview.md) for `git branch`.  It has the same functionality as the corresponding Git subcommand, but supports Sparo's optional anonymous timing metrics collection.
+
+```
+sparo git-branch [--color[=<when>] | --no-color] [--show-current]
+        [-v [--abbrev=<n> | --no-abbrev]]
+        [--column[=<options>] | --no-column] [--sort=<key>]
+        [--merged [<commit>]] [--no-merged [<commit>]]
+        [--contains [<commit>]] [--no-contains [<commit>]]
+        [--points-at <object>] [--format=<format>]
+        [(-r | --remotes) | (-a | --all)]
+        [--list] [<pattern>...]
+sparo git-branch [--track[=(direct|inherit)] | --no-track] [-f]
+        [--recurse-submodules] <branchname> [<start-point>]
+sparo git-branch (--set-upstream-to=<upstream> | -u <upstream>) [<branchname>]
+sparo git-branch --unset-upstream [<branchname>]
+sparo git-branch (-m | -M) [<oldbranch>] <newbranch>
+sparo git-branch (-c | -C) [<oldbranch>] <newbranch>
+sparo git-branch (-d | -D) [-r] <branchname>...
+sparo git-branch --edit-description [<branchname>]
+```
+
+See [git branch](https://git-scm.com/docs/git-branch) in the Git documentation for details.
+

--- a/apps/website/sidebars.js
+++ b/apps/website/sidebars.js
@@ -63,10 +63,12 @@ const sidebars = {
         'pages/commands/sparo_clone',
         'pages/commands/sparo_fetch',
         'pages/commands/sparo_pull',
+        'pages/commands/sparo_branch',
         'pages/commands/sparo_git-checkout',
         'pages/commands/sparo_git-clone',
         'pages/commands/sparo_git-fetch',
         'pages/commands/sparo_git-pull',
+        'pages/commands/sparo_git-branch',
         'pages/commands/sparo_init-profile',
         'pages/commands/sparo_list-profiles'
       ]

--- a/build-tests/sparo-output-test/etc/top-level-help.txt
+++ b/build-tests/sparo-output-test/etc/top-level-help.txt
@@ -22,10 +22,12 @@ Commands:
   sparo fetch [remote] [branch]          fetch remote branch to local
   sparo pull                             Incorporates changes from a remote
                                          repository into the current branch.
+  sparo branch [branch]                  List, create, or delete branches
   sparo git-clone                        original git clone command
   sparo git-checkout                     original git checkout command
   sparo git-fetch                        original git fetch command
   sparo git-pull                         original git pull command
+  sparo git-branch                       original git branch command
 
 Options:
   --help     Show help                                                 [boolean]

--- a/common/changes/sparo/feat-sparo-branch_2024-05-21-23-13.json
+++ b/common/changes/sparo/feat-sparo-branch_2024-05-21-23-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "\"sparo branch -d\" clean up remote fetch git configuration",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}

--- a/common/changes/sparo/feat-sparo-branch_2024-05-21-23-18.json
+++ b/common/changes/sparo/feat-sparo-branch_2024-05-21-23-18.json
@@ -2,11 +2,7 @@
   "changes": [
     {
       "packageName": "sparo",
-<<<<<<< HEAD
       "comment": "Add a renamed command \"sparo git-branch\"",
-=======
-      "comment": "Add a mirror command \"sparo git-branch\"",
->>>>>>> ae8407d (chore: rush change)
       "type": "none"
     }
   ],

--- a/common/changes/sparo/feat-sparo-branch_2024-05-21-23-18.json
+++ b/common/changes/sparo/feat-sparo-branch_2024-05-21-23-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Add a renamed command \"sparo git-branch\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}

--- a/common/changes/sparo/feat-sparo-branch_2024-05-21-23-18.json
+++ b/common/changes/sparo/feat-sparo-branch_2024-05-21-23-18.json
@@ -2,7 +2,11 @@
   "changes": [
     {
       "packageName": "sparo",
+<<<<<<< HEAD
       "comment": "Add a renamed command \"sparo git-branch\"",
+=======
+      "comment": "Add a mirror command \"sparo git-branch\"",
+>>>>>>> ae8407d (chore: rush change)
       "type": "none"
     }
   ],


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Add a new enhanced command "sparo branch".

### Detail

When running "sparo branch -d/-D <branch>", it will automatically clean up the remote fetch git configuation. To prevent a error when running "pull" command when the tracking branch is deleted remotely(such as merged into the main branch).

### How to test it

Local
