### PR TITLE
Feat pull remote fetch

### DIFF
--- a/apps/sparo-lib/src/services/GitRemoteFetchConfigService.ts
+++ b/apps/sparo-lib/src/services/GitRemoteFetchConfigService.ts
@@ -1,0 +1,174 @@
+import { inject } from 'inversify';
+import { Colorize } from '@rushstack/terminal';
+
+import { Service } from '../decorator';
+import { GitService } from './GitService';
+import { TerminalService } from './TerminalService';
+import { GracefulShutdownService } from './GracefulShutdownService';
+
+/**
+ * Helper class for git remote.origin.fetch config
+ *
+ * @alpha
+ */
+@Service()
+export class GitRemoteFetchConfigService {
+  @inject(GitService) private _gitService!: GitService;
+  @inject(TerminalService) private _terminalService!: TerminalService;
+  @inject(GracefulShutdownService) private _gracefulShutdownService!: GracefulShutdownService;
+
+  public addRemoteBranchIfNotExists(remote: string, branch: string): void {
+    const remoteFetchGitConfig: string[] | undefined = this._loadForRemote(remote);
+
+    if (remoteFetchGitConfig) {
+      const targetConfig: string = `+refs/heads/${branch}:refs/remotes/${remote}/${branch}`;
+      if (
+        // Prevents adding remote branch if it is not single branch mode
+        remoteFetchGitConfig.includes(`+refs/heads/*:refs/remotes/${remote}/*`) ||
+        // Prevents adding the same remote branch multiple times
+        remoteFetchGitConfig?.some((value: string) => value === targetConfig)
+      ) {
+        return;
+      }
+    }
+
+    this._gitService.executeGitCommand({
+      args: ['remote', 'set-branches', '--add', remote, branch]
+    });
+  }
+
+  public pruneRemoteBranchesInGitConfigAsync = async (remote: string): Promise<void> => {
+    const remoteFetchConfig: string[] | undefined = this._loadForRemote(remote);
+    if (!remoteFetchConfig) {
+      return;
+    }
+
+    const invalidRemoteFetchConfig: string[] = [];
+    const invalidBranches: string[] = [];
+    const branchToValues: Map<string, Set<string>> = this.getBranchesInfoFromRemoteFetchConfig(
+      remoteFetchConfig
+    );
+    const checkBranches: string[] = Array.from(branchToValues.keys()).filter((x) => x !== '*');
+
+    const remoteBranchExistenceInfo: Record<string, boolean> =
+      await this._gitService.checkRemoteBranchesExistenceAsync(remote, checkBranches);
+
+    for (const [branch, isExists] of Object.entries(remoteBranchExistenceInfo)) {
+      if (isExists) {
+        continue;
+      }
+
+      invalidBranches.push(branch);
+
+      const remoteFetchConfigValues: Set<string> | undefined = branchToValues.get(branch);
+      if (remoteFetchConfigValues) {
+        invalidRemoteFetchConfig.push(...remoteFetchConfigValues);
+      }
+    }
+
+    if (invalidRemoteFetchConfig.length) {
+      for (const invalidBranch of invalidBranches) {
+        this._terminalService.terminal.writeLine(
+          Colorize.gray(
+            `Branch "${invalidBranch}" doesn't exist remotely. It might have been merged into the main branch. Pruning this branch from the git configuration.`
+          )
+        );
+      }
+      const nextRemoteFetchConfigSet: Set<string> = new Set<string>(remoteFetchConfig);
+      this._terminalService.terminal.writeDebugLine(
+        `Pruning the following value(s) in remote.${remote}.fetch from git configuration`
+      );
+      for (const invalidValue of invalidRemoteFetchConfig) {
+        this._terminalService.terminal.writeDebugLine(invalidValue);
+        nextRemoteFetchConfigSet.delete(invalidValue);
+      }
+
+      // Restores previous git configuration if something went wrong
+      const callback = (): void => {
+        this._setRemoteFetchInGitConfig(remote, remoteFetchConfig);
+        this._terminalService.terminal.writeDebugLine(
+          `Restore previous remote.${remote}.fetch to git configuration`
+        );
+      };
+
+      this._gracefulShutdownService.registerCallback(callback);
+      this._setRemoteFetchInGitConfig(remote, Array.from(nextRemoteFetchConfigSet));
+      this._gracefulShutdownService.unregisterCallback(callback);
+    }
+  };
+
+  /**
+   * Sparo uses single branch mode as default. This function switch to all branch mode from single branch mode.
+   * And, it returns a callback function to go back to single branch mode with previous git configuration.
+   * It's used in "sparo fetch --all" command
+   */
+  public revertSingleBranchIfNecessary = (remote: string): (() => void) | undefined => {
+    let remoteFetchGitConfig: string[] | undefined = this._loadForRemote(remote);
+    let callback: (() => void) | undefined;
+    if (remoteFetchGitConfig && !remoteFetchGitConfig.includes(`+refs/heads/*:refs/remotes/${remote}/*`)) {
+      this._setAllBranchFetch(remote);
+
+      callback = () => {
+        if (remoteFetchGitConfig) {
+          this._setRemoteFetchInGitConfig(remote, remoteFetchGitConfig);
+
+          // Avoid memory leaking
+          remoteFetchGitConfig = undefined;
+          this._gracefulShutdownService.unregisterCallback(callback);
+        }
+      };
+
+      this._gracefulShutdownService.registerCallback(callback);
+    }
+
+    return callback;
+  };
+
+  /**
+   * Reads remote.origin.fetch from git configuration. It returns a mapping
+   */
+  public getBranchesInfoFromRemoteFetchConfig(remoteFetchConfig: string[]): Map<string, Set<string>> {
+    const branchRegExp: RegExp = /^(?:\+)?refs\/heads\/([^:]+):/;
+    const branchToValues: Map<string, Set<string>> = new Map<string, Set<string>>();
+    for (const remoteFetchConfigValue of remoteFetchConfig) {
+      const match: RegExpMatchArray | null = remoteFetchConfigValue.match(branchRegExp);
+      if (match) {
+        const branch: string | undefined = match[1];
+        if (branch) {
+          let values: Set<string> | undefined = branchToValues.get(branch);
+          if (!values) {
+            values = new Set<string>();
+            branchToValues.set(branch, values);
+          }
+          values.add(remoteFetchConfigValue);
+        }
+      }
+    }
+    return branchToValues;
+  }
+
+  private _loadForRemote(remote: string): string[] | undefined {
+    const result: string | undefined = this._gitService.getGitConfig(`remote.${remote}.fetch`, {
+      array: true
+    });
+    const remoteFetchGitConfig: string[] | undefined = result?.split('\n').filter(Boolean);
+    return remoteFetchGitConfig;
+  }
+
+  /**
+   * There is no easy way to unset one branch from git configuration
+   * So, delete all remote.origin.fetch configuration and restores expected value
+   */
+  private _setRemoteFetchInGitConfig(remote: string, remoteFetchGitConfig: string[]): void {
+    this._gitService.unsetGitConfig(`remote.${remote}.fetch`);
+    for (const value of remoteFetchGitConfig) {
+      this._gitService.setGitConfig(`remote.${remote}.fetch`, value, { add: true });
+    }
+  }
+
+  private _setAllBranchFetch(remote: string): void {
+    this._gitService.setGitConfig(`remote.${remote}.fetch`, `+refs/heads/*:refs/remotes/${remote}/*`, {
+      replaceAll: true
+    });
+  }
+}

--- a/apps/sparo-lib/src/services/GitService.ts
+++ b/apps/sparo-lib/src/services/GitService.ts
@@ -464,7 +464,7 @@ Please specify a directory on the command line
   /**
    * Check existence for one branch name.
    *
-   * {@link checkRemoteBranchesExistenceAsync} is preferred if you are going to check a list of branch name.
+   * Function "checkRemoteBranchesExistenceAsync" is preferred if you are going to check a list of branch name.
    */
   public checkRemoteBranchExistenceAsync = async (remote: string, branch: string): Promise<boolean> => {
     const gitPath: string = this.getGitPathOrThrow();

--- a/apps/sparo-lib/src/services/test/GitRemoteFetchConfigService.test.ts
+++ b/apps/sparo-lib/src/services/test/GitRemoteFetchConfigService.test.ts
@@ -1,0 +1,28 @@
+import { getFromContainer } from '../../di/container';
+import { GitRemoteFetchConfigService } from '../GitRemoteFetchConfigService';
+
+describe(GitRemoteFetchConfigService.name, () => {
+  const gitRemoteFetchConfigService = getFromContainer(GitRemoteFetchConfigService);
+
+  describe(gitRemoteFetchConfigService.getBranchesInfoFromRemoteFetchConfig, () => {
+    it('should work', () => {
+      const values: string[] = [
+        '+refs/heads/*:refs/remotes/origin/*',
+        '+refs/heads/release:refs/remotes/origin/release',
+        '+refs/heads/feat/abc:refs/remotes/origin/feat/abc'
+      ];
+
+      const expectedContaining: Record<string, string> = {
+        '*': values[0],
+        release: values[1],
+        'feat/abc': values[2]
+      };
+
+      for (const [k, v] of Object.entries(
+        gitRemoteFetchConfigService.getBranchesInfoFromRemoteFetchConfig(values)
+      )) {
+        expect(v).toBe(expect.arrayContaining([expectedContaining[k]]));
+      }
+    });
+  });
+});

--- a/build-tests/sparo-output-test/etc/top-level-help.txt
+++ b/build-tests/sparo-output-test/etc/top-level-help.txt
@@ -20,7 +20,7 @@ Commands:
                                          HEAD to set the specified branch as the
                                          current branch.
   sparo fetch [remote] [branch]          fetch remote branch to local
-  sparo pull                             Incorporates changes from a remote
+  sparo pull [remote]                    Incorporates changes from a remote
                                          repository into the current branch.
   sparo git-clone                        original git clone command
   sparo git-checkout                     original git checkout command

--- a/common/changes/sparo/feat-pull-remote-fetch_2024-05-24-00-11.json
+++ b/common/changes/sparo/feat-pull-remote-fetch_2024-05-24-00-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "\"sparo fetch\" and \"sparo pull\" automatically clean up merged branches from the git configuration before actually invoking git fetch or pull",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}

--- a/common/reviews/api/sparo-lib.api.md
+++ b/common/reviews/api/sparo-lib.api.md
@@ -17,6 +17,8 @@ export function getFromContainerAsync<T>(clazz: Constructable<T>): Promise<T>;
 
 // @alpha
 export class GitService {
+    checkRemoteBranchesExistenceAsync: (remote: string, branches: string[]) => Promise<Record<string, boolean>>;
+    checkRemoteBranchExistenceAsync: (remote: string, branch: string) => Promise<boolean>;
     // (undocumented)
     executeGitCommand({ args, workingDirectory }: IExecuteGitCommandParams): child_process.SpawnSyncReturns<string>;
     // (undocumented)
@@ -24,6 +26,8 @@ export class GitService {
     getBasenameFromUrl(url: string): string;
     // (undocumented)
     getBranchRemote(branch: string): string;
+    // (undocumented)
+    getCurrentBranch(): string;
     // (undocumented)
     getGitConfig(k: string, option?: {
         dryRun?: boolean;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

### Summary

`sparo fetch` and `sparo pull` automatically clean up merged branches from the git configuration before actually invoking git fetch or pull

### Detail

Assuming "nonexistent" branch is tracking in the git configuration. Before "sparo fetch" calls the actual "git fetch" command, it will automatically check the existence of the branch in remote, and remove it from the git configuration if it doesn't exist remotely, such as it has been merged into the main branch.

<img width="1052" alt="image" src="https://github.com/tiktok/sparo/assets/16147702/21ffe822-2dee-45d0-92b8-d73057b97cb7">


### How to test it

Local
