### PR TITLE
fix: sparo pull need to track rush selectors also

### DIFF
--- a/apps/sparo-lib/src/cli/commands/pull.ts
+++ b/apps/sparo-lib/src/cli/commands/pull.ts
@@ -55,10 +55,11 @@ export class PullCommand implements ICommand<IPullCommandOptions> {
     // Collect anything that is not related to profile, pass down them to native git pull
     const pullArgs: string[] = args._ as string[];
 
-    const { isNoProfile, profiles, addProfiles } = await sparoProfileService.preprocessProfileArgs({
-      profilesFromArg: args.profile ?? [],
-      addProfilesFromArg: []
-    });
+    const { isNoProfile, profiles, addProfiles, isProfileRestoreFromLocal } =
+      await sparoProfileService.preprocessProfileArgs({
+        profilesFromArg: args.profile ?? [],
+        addProfilesFromArg: []
+      });
 
     const { remote } = args;
     if (remote) {
@@ -93,7 +94,8 @@ export class PullCommand implements ICommand<IPullCommandOptions> {
     // sync local sparse checkout state with given profiles.
     await this._sparoProfileService.syncProfileState({
       profiles: isNoProfile ? undefined : profiles,
-      addProfiles
+      addProfiles,
+      isProfileRestoreFromLocal
     });
   };
 

--- a/common/changes/sparo/fix-sparo-pull-with-selectors_2024-05-29-01-26.json
+++ b/common/changes/sparo/fix-sparo-pull-with-selectors_2024-05-29-01-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "sparo",
-      "comment": "sparo pull need to track rush selectors also",
+      "comment": "\"sparo pull\" respects temporary rush selectors \"--to\" and \"--from\".",
       "type": "none"
     }
   ],

--- a/common/changes/sparo/fix-sparo-pull-with-selectors_2024-05-29-01-26.json
+++ b/common/changes/sparo/fix-sparo-pull-with-selectors_2024-05-29-01-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "sparo pull need to track rush selectors also",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

### Detail

### How to test it
