### PR TITLE
Supports "sparo checkout -"

### DIFF
--- a/apps/sparo-lib/src/cli/commands/checkout.ts
+++ b/apps/sparo-lib/src/cli/commands/checkout.ts
@@ -122,11 +122,11 @@ export class CheckoutCommand implements ICommand<ICheckoutCommandOptions> {
     if (!branch) {
       const checkoutIndex: number = process.argv.findIndex((value: string) => value === 'checkout');
       if (checkoutIndex >= 0 && process.argv[checkoutIndex + 1] === '-') {
-        branch = '-';
-        // FIXME: supports "sparo checkout -"
-        throw new Error(
-          `Git's "-" token is not yet supported. If this feature is important for your work, please let us know by creating a GitHub issue.`
-        );
+        // - is a shortcut of @{-1}
+        branch = gitService.getPreviousBranch(1);
+        if (!branch) {
+          throw new Error(`Argument "-" is unknown revision or path not in the working tree.`);
+        }
       }
     }
 

--- a/apps/sparo-lib/src/services/GitService.ts
+++ b/apps/sparo-lib/src/services/GitService.ts
@@ -446,6 +446,24 @@ Please specify a directory on the command line
   }
 
   /**
+   * Retrieves the previous branch name using `@{-n}` syntax
+   *
+   * Assume:
+   * git checkout feature
+   * git checkout main
+   * ---
+   * `git checkout @{-1}` equals to run `git checkout feature`.
+   * Running `getPreviousBranch(1)` works in the similar way and returns "feature" in this case.
+   */
+  public getPreviousBranch(n: number): string {
+    const result: string = this.executeGitCommandAndCaptureOutput({
+      args: ['rev-parse', '--symbolic-full-name', '--abbrev-ref=loose', `@{-${n}}`]
+    }).trim();
+    this._terminalService.terminal.writeDebugLine(`getPreviousBranch ${n}: ${result}`);
+    return result;
+  }
+
+  /**
    * Check existence for a list of branch name
    */
   public checkRemoteBranchesExistenceAsync = async (

--- a/common/changes/sparo/feat-checkout-dash_2024-05-30-05-28.json
+++ b/common/changes/sparo/feat-checkout-dash_2024-05-30-05-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "\"sparo checkout -\" can checkout to previous branch correctly",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}

--- a/common/reviews/api/sparo-lib.api.md
+++ b/common/reviews/api/sparo-lib.api.md
@@ -46,6 +46,7 @@ export class GitService {
     getIsSparseCheckoutMode(): boolean | undefined;
     // (undocumented)
     getObjectType(object: string): IObjectType | undefined;
+    getPreviousBranch(n: number): string;
     // (undocumented)
     getRepoInfo(): GitRepoInfo;
     get gitPath(): string | undefined;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Previously, "sparo checkout" throws an error when parsing "-" branch name. Now "sparo checkoout -" can work similiar to "git checkout -" does

### Detail

When parsing "-" branch, sparo reads the logs from `.git/logs/HEAD` from and get the previous branch name. With this branch name, do the following logic as normal.

### How to test it

Local