### PR TITLE
Feat sparo metric

### DIFF
--- a/apps/sparo-lib/src/services/GitRemoteFetchConfigService.ts
+++ b/apps/sparo-lib/src/services/GitRemoteFetchConfigService.ts
@@ -18,7 +18,7 @@ export class GitRemoteFetchConfigService {
   @inject(GracefulShutdownService) private _gracefulShutdownService!: GracefulShutdownService;
 
   public addRemoteBranchIfNotExists(remote: string, branch: string): void {
-    const remoteFetchGitConfig: string[] | undefined = this._loadForRemote(remote);
+    const remoteFetchGitConfig: string[] | undefined = this._getRemoteFetchInGitConfig(remote);
 
     if (remoteFetchGitConfig) {
       const targetConfig: string = `+refs/heads/${branch}:refs/remotes/${remote}/${branch}`;
@@ -38,7 +38,7 @@ export class GitRemoteFetchConfigService {
   }
 
   public pruneRemoteBranchesInGitConfigAsync = async (remote: string): Promise<void> => {
-    const remoteFetchConfig: string[] | undefined = this._loadForRemote(remote);
+    const remoteFetchConfig: string[] | undefined = this._getRemoteFetchInGitConfig(remote);
     if (!remoteFetchConfig) {
       return;
     }
@@ -103,12 +103,12 @@ export class GitRemoteFetchConfigService {
    * It's used in "sparo fetch --all" command
    */
   public revertSingleBranchIfNecessary = (remote: string): (() => void) | undefined => {
-    let remoteFetchGitConfig: string[] | undefined = this._loadForRemote(remote);
+    let remoteFetchGitConfig: string[] | undefined = this._getRemoteFetchInGitConfig(remote);
     let callback: (() => void) | undefined;
     if (remoteFetchGitConfig && !remoteFetchGitConfig.includes(`+refs/heads/*:refs/remotes/${remote}/*`)) {
       this._setAllBranchFetch(remote);
 
-      callback = () => {
+      callback = (): void => {
         if (remoteFetchGitConfig) {
           this._setRemoteFetchInGitConfig(remote, remoteFetchGitConfig);
 
@@ -147,7 +147,7 @@ export class GitRemoteFetchConfigService {
     return branchToValues;
   }
 
-  private _loadForRemote(remote: string): string[] | undefined {
+  private _getRemoteFetchInGitConfig(remote: string): string[] | undefined {
     const result: string | undefined = this._gitService.getGitConfig(`remote.${remote}.fetch`, {
       array: true
     });
@@ -160,9 +160,10 @@ export class GitRemoteFetchConfigService {
    * So, delete all remote.origin.fetch configuration and restores expected value
    */
   private _setRemoteFetchInGitConfig(remote: string, remoteFetchGitConfig: string[]): void {
-    this._gitService.unsetGitConfig(`remote.${remote}.fetch`);
+    const key: string = `remote.${remote}.fetch`;
+    this._gitService.unsetGitConfig(key);
     for (const value of remoteFetchGitConfig) {
-      this._gitService.setGitConfig(`remote.${remote}.fetch`, value, { add: true });
+      this._gitService.setGitConfig(key, value, { add: true });
     }
   }
 

--- a/apps/sparo-lib/src/services/GitRemoteFetchConfigService.ts
+++ b/apps/sparo-lib/src/services/GitRemoteFetchConfigService.ts
@@ -50,6 +50,8 @@ export class GitRemoteFetchConfigService {
     );
     const checkBranches: string[] = Array.from(branchToValues.keys()).filter((x) => x !== '*');
 
+    this._terminalService.terminal.writeLine(`Checking tracking branches...`);
+
     const remoteBranchExistenceInfo: Record<string, boolean> =
       await this._gitService.checkRemoteBranchesExistenceAsync(remote, checkBranches);
 

--- a/apps/sparo-lib/src/services/TerminalService.ts
+++ b/apps/sparo-lib/src/services/TerminalService.ts
@@ -65,6 +65,10 @@ export class TerminalService {
     this._terminal.writeLine(Colorize.gray('-'.repeat(this._asciiHeaderWidth)));
     this._terminal.writeLine();
   }
+
+  public get isDebug(): boolean {
+    return this._terminalProvider.debugEnabled;
+  }
 }
 
 export type { ITerminal };

--- a/common/changes/sparo/feat-sparo-metric_2024-06-27-23-23.json
+++ b/common/changes/sparo/feat-sparo-metric_2024-06-27-23-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Improve logic to check existence of a branch",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}

--- a/common/changes/sparo/feat-sparo-metric_2024-06-27-23-46.json
+++ b/common/changes/sparo/feat-sparo-metric_2024-06-27-23-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Enhance metric logic to accurately report success data",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}

--- a/common/reviews/api/sparo-lib.api.md
+++ b/common/reviews/api/sparo-lib.api.md
@@ -122,6 +122,8 @@ export class Sparo {
 export class TerminalService {
     constructor();
     // (undocumented)
+    get isDebug(): boolean;
+    // (undocumented)
     setIsDebug(value: boolean): void;
     // (undocumented)
     setIsVerbose(value: boolean): void;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

### Summary

1. Improve the logic to check existence of a branch
2. Improve the logic to accurately report success data

### Detail

1. `git ls-remote --exist-code` explicitly returns exit code 2 to indicate the branch is missing remotely. The new logic respects this logic, that says other exit code will be treated the branch exists remotely.
![CleanShot 2024-06-27 at 16 51 03@2x](https://github.com/tiktok/sparo/assets/16147702/3fd36b28-47b0-4f38-89e7-54a3591f163b)


2. Previously, all data are sent via telemetry service. After this PR, data will be sent only for success commands.

### How to test it

Local
