### PR TITLE
Automatically set up recommended git configuration even when full clone

### DIFF
--- a/common/changes/sparo/feat-clone-full_2024-07-11-21-24.json
+++ b/common/changes/sparo/feat-clone-full_2024-07-11-21-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "sparo",
-      "comment": "Automatically set up recommended git configuration even when full clone",
+      "comment": "Automatically set up recommended git configuration even when performing a full clone",
       "type": "none"
     }
   ],

--- a/common/changes/sparo/feat-clone-full_2024-07-11-21-24.json
+++ b/common/changes/sparo/feat-clone-full_2024-07-11-21-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Automatically set up recommended git configuration even when full clone",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Automatically set up recommended git configuration even when full clone

### Detail

### How to test it
