### PR TITLE
"sparo fetch" behaves the same as "git fetch" when no remote or no branches specified

### DIFF
--- a/common/changes/sparo/feat-fetch-behavior_2024-07-11-22-08.json
+++ b/common/changes/sparo/feat-fetch-behavior_2024-07-11-22-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "\"sparo fetch\" behaves the same as \"git fetch\" when no remote or no branches specified",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

### Summary

"sparo fetch" behaves the same as "git fetch" when no remote or no branches specified

### Detail

Right now, `sparo fetch origin` will be treated as `git fetch origin <current_branch>`. This doesn't follow the same behavior as `git fetch` does. This PR fixes it and get aligned with `git fetch`

### How to test it
