### PR TITLE
fix: website build

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -221,7 +221,7 @@
    *
    * PNPM documentation: https://pnpm.io/package_json#pnpmpatcheddependencies
    */
-  "globalPatchedDependencies": {},
+  "globalPatchedDependencies": { "lunr@2.3.9": "patches/lunr@2.3.9.patch" },
 
   /**
    * (USE AT YOUR OWN RISK)  This is a free-form property bag that will be copied into

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  lunr@2.3.9:
+    hash: pgt6qd4rzkalm6lxuf4rydzxte
+    path: patches/lunr@2.3.9.patch
+
 importers:
 
   .: {}
@@ -116,7 +121,7 @@ importers:
         version: 3.3.2(@docusaurus/core@3.1.1)(react-dom@18.2.0)(react@18.2.0)
       lunr:
         specifier: ^2.3.9
-        version: 2.3.9
+        version: 2.3.9(patch_hash=pgt6qd4rzkalm6lxuf4rydzxte)
       lunr-languages:
         specifier: ^1.14.0
         version: 1.14.0
@@ -5836,7 +5841,7 @@ packages:
       hast-util-select: 4.0.2
       hast-util-to-text: 2.0.1
       hogan.js: 3.0.2
-      lunr: 2.3.9
+      lunr: 2.3.9(patch_hash=pgt6qd4rzkalm6lxuf4rydzxte)
       lunr-languages: 1.14.0
       mark.js: 8.11.1
       minimatch: 3.1.2
@@ -8673,9 +8678,10 @@ packages:
     resolution: {integrity: sha512-hWUAb2KqM3L7J5bcrngszzISY4BxrXn/Xhbb9TTCJYEGqlR1nG67/M14sp09+PTIRklobrn57IAxcdcO/ZFyNA==}
     dev: false
 
-  /lunr@2.3.9:
+  /lunr@2.3.9(patch_hash=pgt6qd4rzkalm6lxuf4rydzxte):
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
     dev: false
+    patched: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}

--- a/common/pnpm-patches/lunr@2.3.9.patch
+++ b/common/pnpm-patches/lunr@2.3.9.patch
@@ -1,0 +1,18 @@
+diff --git a/.npmignore b/.npmignore
+deleted file mode 100644
+index dee86324b64e82374e8a5bc6bee027bbec12022c..0000000000000000000000000000000000000000
+diff --git a/lunr.js b/lunr.js
+index 6aa370fbcb7b1b94eb8a19c433a5038352183b2a..a1bbd049d275fbdca3cf904f494a86ae1f305a00 100644
+--- a/lunr.js
++++ b/lunr.js
+@@ -76,8 +76,8 @@ lunr.utils = {}
+ lunr.utils.warn = (function (global) {
+   /* eslint-disable no-console */
+   return function (message) {
+-    if (global.console && console.warn) {
+-      console.warn(message)
++    if (global.console && console.log) {
++      console.log('[WARN]', message)
+     }
+   }
+   /* eslint-enable no-console */


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [ ] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Patch `lunr.utils.warn` to use `console.log` instead of `console.warn`

### Detail

![img_v3_02e7_60738ba2-2453-4e65-bcf2-916e3b7f40hu](https://github.com/user-attachments/assets/26447d79-7bb7-42d4-97a8-256ce9eb6875)

Lunr prints error message with `console.warn` which print on stderr. The messages are treated as error message by `rush build`

After patching the code of lunr, it uses `console.log` to print the message.


### How to test it

Local
