### PR TITLE
Fix branch fetch config

### DIFF
--- a/apps/sparo-lib/src/cli/commands/checkout.ts
+++ b/apps/sparo-lib/src/cli/commands/checkout.ts
@@ -281,6 +281,9 @@ export class CheckoutCommand implements ICommand<ICheckoutCommandOptions> {
             }
           }
         }
+      } else {
+        const remote: string = this._gitService.getBranchRemote(operationBranch);
+        this._gitRemoteFetchConfigService.addRemoteBranchIfNotExists(remote, operationBranch);
       }
     }
 

--- a/apps/sparo-lib/src/services/GitRemoteFetchConfigService.ts
+++ b/apps/sparo-lib/src/services/GitRemoteFetchConfigService.ts
@@ -35,6 +35,11 @@ export class GitRemoteFetchConfigService {
     this._gitService.executeGitCommand({
       args: ['remote', 'set-branches', '--add', remote, branch]
     });
+
+    // Example: branch.feature-foo.remote=origin
+    this._gitService.setGitConfig(`branch.${branch}.remote`, remote);
+    // Example: branch.feature-foo.merge=refs/heads/feature-foo
+    this._gitService.setGitConfig(`branch.${branch}.merge`, `refs/heads/${branch}`);
   }
 
   public pruneRemoteBranchesInGitConfigAsync = async (remote: string): Promise<void> => {
@@ -96,6 +101,12 @@ export class GitRemoteFetchConfigService {
       this._gracefulShutdownService.registerCallback(callback);
       this._setRemoteFetchInGitConfig(remote, Array.from(nextRemoteFetchConfigSet));
       this._gracefulShutdownService.unregisterCallback(callback);
+
+      // Clean up other git configurations
+      for (const invalidBranch of invalidBranches) {
+        this._gitService.unsetGitConfig(`branch.${invalidBranch}.remote`);
+        this._gitService.unsetGitConfig(`branch.${invalidBranch}.merge`);
+      }
     }
   };
 

--- a/common/changes/sparo/fix-branch-fetch-config_2024-09-23-22-33.json
+++ b/common/changes/sparo/fix-branch-fetch-config_2024-09-23-22-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Fix git configs for tracking branch",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Fix git configurations for tracking branch

### Detail

Because of single branch mode, we need to put extra efforts on git configuration for feature branches. `branch.<branch>.remote` and `branch.<branch>.merge` was reported missing in user enviornment. This MR takes care of these two git configurations when checking out branches.

### How to test it

Tested locally
