### PR TITLE
fix: use more accurate pattern when checking remote branch existence

### DIFF
--- a/apps/sparo-lib/src/services/GitService.ts
+++ b/apps/sparo-lib/src/services/GitService.ts
@@ -496,7 +496,8 @@ Please specify a directory on the command line
     const gitPath: string = this.getGitPathOrThrow();
     const currentWorkingDirectory: string = this.getRepoInfo().root;
     const isDebug: boolean = this._terminalService.isDebug;
-    const lsRemoteArgs: string[] = ['ls-remote', '--exit-code', '--heads', remote, branch];
+    const branchPattern: string = `refs/heads/${branch}`;
+    const lsRemoteArgs: string[] = ['ls-remote', '--exit-code', '--heads', remote, branchPattern];
     const { terminal } = this._terminalService;
     terminal.writeDebugLine(`Running git ${lsRemoteArgs.join(' ')}...`);
     const childProcess: child_process.ChildProcess = Executable.spawn(gitPath, lsRemoteArgs, {
@@ -506,7 +507,7 @@ Please specify a directory on the command line
     if (!childProcess.stdout || !childProcess.stderr) {
       terminal.writeDebugLine(`Failed to spawn git process, fallback to spawnSync`);
       const result: string = this.executeGitCommandAndCaptureOutput({
-        args: ['ls-remote', remote, branch]
+        args: ['ls-remote', remote, branchPattern]
       }).trim();
       return Promise.resolve(!!result);
     }

--- a/common/changes/sparo/fix-exact-pattern_2025-03-18-20-55.json
+++ b/common/changes/sparo/fix-exact-pattern_2025-03-18-20-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "fix: use more accurate pattern when checking remote branch existence #99",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

When checking for the existence of a remote branch, `git ls-remote` uses a [glob pattern](https://git-scm.com/docs/git-ls-remote) to filter all matched remote branches. 
This can sometimes produce incorrect results. For example, checking for `refs/heads/test` with the pattern test will also match the branch `refs/heads/others/test`.

### Detail

### How to test it
