### PR TITLE
Polish user-facing text across Sparo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ## Key features
 
 - **Familiar interface:** The `sparo` command-line interface (CLI) wrapper offers **better defaults** and **performance suggestions** without altering the familiar `git` syntax. (The native `git` CLI is also supported.)
-- **A proven solution:** Git provides [quite a lot of ingredients](https://tiktok.github.io/sparo/pages/reference/git_optimization/) for optimizing very large repos; Sparo is your recipe for combining these features intelligently.
-- **Simplified sparse checkout:** Work with sparse checkout [profiles](https://tiktok.github.io/sparo/pages/guide/sparo_profiles/) instead of confusing "cones" and globs
+- **A proven solution:** Git provides [quite a lot of ingredients](./pages/guide/git_features.md) for optimizing very large repos; Sparo is your recipe for combining these features intelligently.
+- **Simplified sparse checkout:** Work with sparse checkout [profiles](./pages/guide/sparo_profiles.md) instead of confusing "cones" and globs
 - **Frontend integration:** Sparo leverages [Rush](https://rushjs.io/) and [PNPM](https://pnpm.io/) workspace configurations, including the ability to automatically checkout project dependencies
 - **Dual workflows:** The `sparo-ci` tool implements a specialized checkout model optimized for continuous integration (CI) pipelines
 - **Extra safeguards**: Avoid common Git mistakes such as checkouts with staged files outside the active view

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ## Key features
 
 - **Familiar interface:** The `sparo` command-line interface (CLI) wrapper offers **better defaults** and **performance suggestions** without altering the familiar `git` syntax. (The native `git` CLI is also supported.)
-- **A proven solution:** Git provides [quite a lot of ingredients](./pages/guide/git_features.md) for optimizing very large repos; Sparo is your recipe for combining these features intelligently.
-- **Simplified sparse checkout:** Work with sparse checkout [profiles](./pages/guide/sparo_profiles.md) instead of confusing "cones" and globs
+- **A proven solution:** Git provides [quite a lot of ingredients](https://tiktok.github.io/sparo/pages/reference/git_optimization/) for optimizing very large repos; Sparo is your recipe for combining these features intelligently.
+- **Simplified sparse checkout:** Work with sparse checkout [profiles](https://tiktok.github.io/sparo/pages/guide/sparo_profiles/) instead of confusing "cones" and globs
 - **Frontend integration:** Sparo leverages [Rush](https://rushjs.io/) and [PNPM](https://pnpm.io/) workspace configurations, including the ability to automatically checkout project dependencies
 - **Dual workflows:** The `sparo-ci` tool implements a specialized checkout model optimized for continuous integration (CI) pipelines
 - **Extra safeguards**: Avoid common Git mistakes such as checkouts with staged files outside the active view
@@ -78,7 +78,7 @@ Building the projects in this monorepo:
    rush build
    ```
 
-How to invoke your locally build `sparo` command:
+How to invoke your locally built `sparo` command:
 
 ```shell
 cd apps/sparo

--- a/apps/sparo-lib/package.json
+++ b/apps/sparo-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sparo-lib",
   "version": "1.9.0",
-  "description": "A library for writing scripts that interact with the Sparo",
+  "description": "A library for writing scripts that interact with Sparo",
   "license": "MIT",
   "homepage": "https://tiktok.github.io/sparo/",
   "repository": {

--- a/apps/sparo-lib/src/cli/commands/auto-config.ts
+++ b/apps/sparo-lib/src/cli/commands/auto-config.ts
@@ -15,7 +15,7 @@ export interface IAutoConfigCommandOptions {
 @Command()
 export class AutoConfigCommand implements ICommand<IAutoConfigCommandOptions> {
   public cmd: string = 'auto-config';
-  public description: string = 'Automatic setup optimized git config';
+  public description: string = 'Automatically set up optimized git config';
   @inject(GitService) private _gitService!: GitService;
 
   public builder(yargs: Argv<IAutoConfigCommandOptions>): void {

--- a/apps/sparo-lib/src/cli/commands/checkout.ts
+++ b/apps/sparo-lib/src/cli/commands/checkout.ts
@@ -45,7 +45,7 @@ export class CheckoutCommand implements ICommand<ICheckoutCommandOptions> {
      * git checkout [-f|--ours|--theirs|-m|--conflict=<style>] --pathspec-from-file=<file> [--pathspec-file-nul]
      * git checkout (-p|--patch) [<tree-ish>] [--] [<pathspec>...]
      *
-     * The above list shows all the functions of the `git checkout` command. Currently, only the following two basic scenarios
+     * The above list shows all the functions of the `git checkout` command. Currently, only the following three basic scenarios
      *  have been implemented, while other scenarios are yet to be implemented.
      * 1. sparo checkout [-b|-B] <new-branch> [start-point] [--profile <profile...>]
      * 2. sparo checkout [branch] [--profile <profile...>]
@@ -294,7 +294,7 @@ export class CheckoutCommand implements ICommand<ICheckoutCommandOptions> {
         profilesFromArg: args.profile
       });
 
-    // Check wether profiles exist in local or operation branch
+    // Check whether profiles exist in local or operation branch
     // Skip check in the following cases:
     // 1. No profile
     // 2. The target kind is file path

--- a/apps/sparo-lib/src/cli/commands/fetch.ts
+++ b/apps/sparo-lib/src/cli/commands/fetch.ts
@@ -17,7 +17,7 @@ export interface IFetchCommandOptions {
 @Command()
 export class FetchCommand implements ICommand<IFetchCommandOptions> {
   public cmd: string = 'fetch [remote] [branch]';
-  public description: string = 'fetch remote branch to local';
+  public description: string = 'Fetch a remote branch to local';
 
   @inject(GitService) private _gitService!: GitService;
   @inject(GitRemoteFetchConfigService) private _gitRemoteFetchConfigService!: GitRemoteFetchConfigService;

--- a/apps/sparo-lib/src/cli/commands/git-checkout.ts
+++ b/apps/sparo-lib/src/cli/commands/git-checkout.ts
@@ -9,7 +9,7 @@ import type { ICommand } from './base';
 @Command()
 export class GitCheckoutCommand implements ICommand<{}> {
   public cmd: string = 'git-checkout';
-  public description: string = 'original git checkout command';
+  public description: string = 'Original git checkout command';
   @inject(GitService) private _gitService!: GitService;
 
   public builder(yargs: Argv<{}>): void {

--- a/apps/sparo-lib/src/cli/commands/git-clone.ts
+++ b/apps/sparo-lib/src/cli/commands/git-clone.ts
@@ -9,7 +9,7 @@ import type { ICommand } from './base';
 @Command()
 export class GitCloneCommand implements ICommand<{}> {
   public cmd: string = 'git-clone';
-  public description: string = 'original git clone command';
+  public description: string = 'Original git clone command';
   @inject(GitService) private _gitService!: GitService;
 
   public builder(yargs: Argv<{}>): void {

--- a/apps/sparo-lib/src/cli/commands/git-fetch.ts
+++ b/apps/sparo-lib/src/cli/commands/git-fetch.ts
@@ -9,7 +9,7 @@ import type { ICommand } from './base';
 @Command()
 export class GitFetchCommand implements ICommand<{}> {
   public cmd: string = 'git-fetch';
-  public description: string = 'original git fetch command';
+  public description: string = 'Original git fetch command';
 
   @inject(GitService) public _gitService!: GitService;
 

--- a/apps/sparo-lib/src/cli/commands/git-pull.ts
+++ b/apps/sparo-lib/src/cli/commands/git-pull.ts
@@ -9,7 +9,7 @@ import type { ICommand } from './base';
 @Command()
 export class GitPullCommand implements ICommand<{}> {
   public cmd: string = 'git-pull';
-  public description: string = 'original git pull command';
+  public description: string = 'Original git pull command';
   @inject(GitService) public _gitService!: GitService;
 
   public builder(yargs: Argv<{}>): void {

--- a/apps/sparo-lib/src/cli/commands/list-profiles.ts
+++ b/apps/sparo-lib/src/cli/commands/list-profiles.ts
@@ -32,7 +32,7 @@ export class ListProfilesCommand implements ICommand<IListProfilesCommandOptions
     yargs
       .option('project', {
         type: 'string',
-        description: 'List all profiles contains this specified project name'
+        description: 'List all profiles that contain this specified project name'
       })
       .completion('completion', false, (current, argv, done) => {
         const longParameters: string[] = [argv.project ? '' : '--project'].filter(Boolean);

--- a/apps/sparo-lib/src/logic/GitVersionCompatibility.ts
+++ b/apps/sparo-lib/src/logic/GitVersionCompatibility.ts
@@ -16,7 +16,7 @@ export class GitVersionCompatibility {
     if (major < 2 || minor < 43) {
       const terminalService: TerminalService = getFromContainer(TerminalService);
       terminalService.terminal.writeErrorLine(
-        `It appears your Git version(${major}.${minor}.${patch}) is too old. The minimal supported version is >=2.43.0.\nPlease upgrade to the latest Git version. Many Git optimizations are relatively new and not available in older versions of the software.`
+        `It appears your Git version (${major}.${minor}.${patch}) is too old. The minimum supported version is >=2.43.0.\nPlease upgrade to the latest Git version. Many Git optimizations are relatively new and not available in older versions of the software.`
       );
       return true;
     }

--- a/apps/sparo-lib/src/services/GitService.ts
+++ b/apps/sparo-lib/src/services/GitService.ts
@@ -156,7 +156,7 @@ export class GitService {
       }
     }
     if (hasExistingConfig && !overwrite) {
-      throw new Error(`git config already exist: \n${errors.join('\n')}`);
+      throw new Error(`git config already exists:\n${errors.join('\n')}`);
     } else {
       for (const item of recommendedConfigs) {
         this.setGitConfig(item[0], item[1], { global: item[2] === 1, dryRun });

--- a/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
+++ b/apps/sparo-lib/src/services/GitSparseCheckoutService.ts
@@ -199,7 +199,7 @@ export class GitSparseCheckoutService {
     additionalFullPackageNames = [];
 
     if (unfoundedPackages.length > 0) {
-      throw new Error(`These packages: ${unfoundedPackages.join(', ')} does not exist in rush.json`);
+      throw new Error(`These packages do not exist in rush.json: ${unfoundedPackages.join(', ')}`);
     }
 
     let targetFolders: string[] = [];

--- a/apps/sparo-lib/src/services/SelectionParameterService.ts
+++ b/apps/sparo-lib/src/services/SelectionParameterService.ts
@@ -100,7 +100,7 @@ export class SelectionParameterService {
     for (const toSelector of toSelectors) {
       const rushProjectSlim: RushProjectSlim | undefined = packageNameToRushProjectSlim.get(toSelector);
       if (!rushProjectSlim) {
-        throw new Error(`Can not found project definition for "${toSelector}"`);
+        throw new Error(`Cannot find project definition for "${toSelector}"`);
       }
       evalToSelectorForProject(rushProjectSlim);
     }
@@ -123,7 +123,7 @@ export class SelectionParameterService {
     for (const fromSelector of fromSelectors) {
       const rushProjectSlim: RushProjectSlim | undefined = packageNameToRushProjectSlim.get(fromSelector);
       if (!rushProjectSlim) {
-        throw new Error(`Can not found project definition for "${fromSelector}"`);
+        throw new Error(`Cannot find project definition for "${fromSelector}"`);
       }
       evalFromSelectorForProject(rushProjectSlim);
     }

--- a/apps/website/docs/index.md
+++ b/apps/website/docs/index.md
@@ -44,7 +44,7 @@ Sparo optimizes performance of Git operations for your large frontend monorepo.
 
 Try out Sparo in 5 easy steps:
 
-1. _**Upgrade to the latest Git version!**_ For macOS, we recommend to use [brew install git](https://git-scm.com/download/mac).  For other operating systems, see the [Git documentation](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) for instructions.
+1. _**Upgrade to the latest Git version!**_ For macOS, we recommend using [brew install git](https://git-scm.com/download/mac).  For other operating systems, see the [Git documentation](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) for instructions.
 
 2. For this demo, we'll use the Azure SDK which is a large public [RushJS](https://rushjs.io/) monorepo from GitHub.  The following command will check out the [skeleton folders](./pages/reference/skeleton_folders.md) but not the source code:
 

--- a/apps/website/docs/pages/commands/sparo_auto-config.md
+++ b/apps/website/docs/pages/commands/sparo_auto-config.md
@@ -5,7 +5,7 @@ title: sparo auto-config
 ```
 sparo auto-config
 
-Automatic setup optimized git config
+Automatically set up optimized git config
 
 Options:
   -h, --help       Show help                                           [boolean]

--- a/apps/website/docs/pages/commands/sparo_fetch.md
+++ b/apps/website/docs/pages/commands/sparo_fetch.md
@@ -5,7 +5,7 @@ title: sparo fetch
 ```
 sparo fetch [remote] [branch]
 
-fetch remote branch to local
+Fetch a remote branch to local
 
 Positionals:
   remote                                                                [string]

--- a/apps/website/docs/pages/commands/sparo_list-profiles.md
+++ b/apps/website/docs/pages/commands/sparo_list-profiles.md
@@ -10,5 +10,5 @@ name
 
 Options:
   -h, --help     Show help                                             [boolean]
-      --project  List all profiles contains this specified project name [string]
+      --project  List all profiles that contain this specified project name [string]
 ```

--- a/build-tests/sparo-completion-test/etc/sparo-top-level-2-completion.txt
+++ b/build-tests/sparo-completion-test/etc/sparo-top-level-2-completion.txt
@@ -1,15 +1,15 @@
 Running "sparo --get-yargs-completions sparo ":
-auto-config:Automatic setup optimized git config
+auto-config:Automatically set up optimized git config
 list-profiles:List all available profiles or query profiles that contain the specified project name
 init-profile:Initialize a new profile.
 clone:Clone a repository into a new directory
 checkout:Updates files in the working tree to match the version in the index or the specified tree. If no pathspec was given, git checkout will also update HEAD to set the specified branch as the current branch.
-fetch:fetch remote branch to local
+fetch:Fetch a remote branch to local
 pull:Incorporates changes from a remote repository into the current branch.
-git-clone:original git clone command
-git-checkout:original git checkout command
-git-fetch:original git fetch command
-git-pull:original git pull command
+git-clone:Original git clone command
+git-checkout:Original git checkout command
+git-fetch:Original git fetch command
+git-pull:Original git pull command
 add:add file contents to the index
 branch:list, create, or delete branches
 commit:record changes to the repository

--- a/build-tests/sparo-completion-test/etc/sparo-top-level-completion.txt
+++ b/build-tests/sparo-completion-test/etc/sparo-top-level-completion.txt
@@ -1,15 +1,15 @@
 Running "sparo --get-yargs-completions sparo":
-auto-config:Automatic setup optimized git config
+auto-config:Automatically set up optimized git config
 list-profiles:List all available profiles or query profiles that contain the specified project name
 init-profile:Initialize a new profile.
 clone:Clone a repository into a new directory
 checkout:Updates files in the working tree to match the version in the index or the specified tree. If no pathspec was given, git checkout will also update HEAD to set the specified branch as the current branch.
-fetch:fetch remote branch to local
+fetch:Fetch a remote branch to local
 pull:Incorporates changes from a remote repository into the current branch.
-git-clone:original git clone command
-git-checkout:original git checkout command
-git-fetch:original git fetch command
-git-pull:original git pull command
+git-clone:Original git clone command
+git-checkout:Original git checkout command
+git-fetch:Original git fetch command
+git-pull:Original git pull command
 add:add file contents to the index
 branch:list, create, or delete branches
 commit:record changes to the repository

--- a/build-tests/sparo-completion-test/package.json
+++ b/build-tests/sparo-completion-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparo-completion-test",
-  "description": "Building this project tests Sparo command-line outputs",
+  "description": "Building this project tests Sparo command-completion outputs",
   "version": "1.0.0",
   "private": true,
   "scripts": {

--- a/build-tests/sparo-output-test/etc/top-level-help.txt
+++ b/build-tests/sparo-output-test/etc/top-level-help.txt
@@ -7,7 +7,8 @@ Git version is __VERSION__
 sparo [command]
 
 Commands:
-  sparo auto-config                      Automatic setup optimized git config
+  sparo auto-config                      Automatically set up optimized git
+                                         config
   sparo list-profiles                    List all available profiles or query
                                          profiles that contain the specified
                                          project name
@@ -19,13 +20,13 @@ Commands:
                                          given, git checkout will also update
                                          HEAD to set the specified branch as the
                                          current branch.
-  sparo fetch [remote] [branch]          fetch remote branch to local
+  sparo fetch [remote] [branch]          Fetch a remote branch to local
   sparo pull [remote]                    Incorporates changes from a remote
                                          repository into the current branch.
-  sparo git-clone                        original git clone command
-  sparo git-checkout                     original git checkout command
-  sparo git-fetch                        original git fetch command
-  sparo git-pull                         original git pull command
+  sparo git-clone                        Original git clone command
+  sparo git-checkout                     Original git checkout command
+  sparo git-fetch                        Original git fetch command
+  sparo git-pull                         Original git pull command
 
 Options:
   --help     Show help                                                 [boolean]

--- a/common/changes/sparo/main_2026-06-10-20-10-10.json
+++ b/common/changes/sparo/main_2026-06-10-20-10-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "sparo",
+      "comment": "Improve user-facing messages",
+      "type": "none"
+    }
+  ],
+  "packageName": "sparo"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "sparo",
     "definitionName": "lockStepVersion",
     "version": "1.9.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "sparo"
   }
 ]

--- a/zsh-plugin/sparo/install.sh
+++ b/zsh-plugin/sparo/install.sh
@@ -4,7 +4,7 @@ BRANCH=${1:-main}
 
 # check ZSH environment
 if [ -z "$ZSH" ]; then
-    echo "ZSH environment variable does not defined."
+    echo "ZSH environment variable is not defined."
     exit 1
 fi
 


### PR DESCRIPTION
Several strings that Sparo users actually see have small grammar and wording problems. None of this changes behavior, but it is the surface that shapes a first impression: the `--help` output, the error messages people hit when something goes wrong, and the docs they read.

This cleans up that surface. Command descriptions in `--help` now read consistently instead of mixing lowercase fragments with full sentences, error messages with broken phrasing (such as when a project can't be found) now read clearly, and a few wording slips on the docs site are fixed.

No functional change to how Sparo works.